### PR TITLE
Add .NET 8 targets (plus some GHA extensions)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
@@ -29,19 +31,21 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build Lib
-      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release
+      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=$(git describe --tags)
     - name: Upload package
       uses: actions/upload-artifact@v3
       with:
         name: nupkg
         path: ./Camera.MAUI/bin/Release/*.nupkg
     - name: Build Test
-      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release
+      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release -p:Version=$(git describe --tags)
 
   macBuild:
     runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
@@ -55,6 +59,6 @@ jobs:
         dotnet workload restore
         dotnet restore
     - name: Build Lib
-      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release
+      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=$(git describe --tags)
     - name: Build Test
-      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release
+      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release -p:Version=$(git describe --tags)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,10 +12,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
 
+  winBuild:
     runs-on: windows-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET
@@ -36,5 +35,26 @@ jobs:
       with:
         name: nupkg
         path: ./Camera.MAUI/bin/Release/*.nupkg
+    - name: Build Test
+      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release
+
+  macBuild:
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
+    - name: Setup XCode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15'
+    - name: Restore workloads & dependencies
+      run: |
+        dotnet workload restore
+        dotnet restore
+    - name: Build Lib
+      run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release
     - name: Build Test
       run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -37,7 +37,15 @@
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
 	  <MtouchLink>SdkOnly</MtouchLink>
 	</PropertyGroup>
-	
+
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+	    <RuntimeIdentifier>maccatalyst-arm64</RuntimeIdentifier>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
+	    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
@@ -60,7 +68,7 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 	</ItemGroup>
-	
+
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Maui" Version="5.0.0" />
 		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="1.0.2" />

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net7.0;net7.0-android;net7.0-ios;net7.0-maccatalyst;net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen;net8.0-tizen<</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -33,17 +33,10 @@
 		<Version>1.4.5</Version>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)'=='net7.0-ios'">
-	  <ProvisioningType>manual</ProvisioningType>
-	</PropertyGroup>
-
 	<ItemGroup>
 	  <Folder Include="Platforms\iOS\" />
 	  <Folder Include="Platforms\MacCatalyst\" />
 	  <Folder Include="Platforms\Tizen\" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0-android'">
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -51,6 +51,11 @@
 	  </None>
 	</ItemGroup>
 
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+	</ItemGroup>
+
 	<ItemGroup>
 	  <PackageReference Include="ZXing.Net" Version="0.16.9" />
 	</ItemGroup>


### PR DESCRIPTION
The library now has both .NET 7 and .NET 8 targets.

Furthermore the GHA build is extended to also build on Mac (in addition to Windows) and uses more precise versioning for the built nupkg.

Unfortunately the GHA build on Windows still fails, but only in the Test project (I couldn't get it to work).