### PR TITLE
StartRecordingAsync: add parameters 'frameRate' and 'bitRate', select format via extension (on Android)

### DIFF
--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -113,7 +113,7 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
             }
         }
     }
-    public async Task<CameraResult> StartRecordingAsync(string file, Size Resolution)
+    public async Task<CameraResult> StartRecordingAsync(string file, Size Resolution, int frameRate, int bitRate)
     {
         CameraResult result = CameraResult.Success;
         if (initiated)

--- a/Camera.MAUI/CameraView.cs
+++ b/Camera.MAUI/CameraView.cs
@@ -464,7 +464,7 @@ public class CameraView : View, ICameraView
     }
     /// <summary>
     /// Start recording a video async. "Camera" property must not be null.
-    /// <paramref name="file"/> Full path to file where video will be stored.
+    /// <paramref name="file"/> Full path to file where video will be stored. On Android, the following formats are supported: .3gp, .mp4 and .webm.
     /// <paramref name="Resolution"/> Sets the Video Resolution. It must be in Camera.AvailableResolutions. If width or height is 0, max resolution will be taken.
     /// <paramref name="frameRate"/> Desired frame rate of the recording in Hz (default: 30). Only supported on Android.
     /// <paramref name="bitRate"/> Desired bitrate of the recording in bps (default: 10M). Only supported on Android.

--- a/Camera.MAUI/CameraView.cs
+++ b/Camera.MAUI/CameraView.cs
@@ -466,8 +466,10 @@ public class CameraView : View, ICameraView
     /// Start recording a video async. "Camera" property must not be null.
     /// <paramref name="file"/> Full path to file where video will be stored.
     /// <paramref name="Resolution"/> Sets the Video Resolution. It must be in Camera.AvailableResolutions. If width or height is 0, max resolution will be taken.
+    /// <paramref name="frameRate"/> Desired frame rate of the recording in Hz (default: 30). Only supported on Android.
+    /// <paramref name="bitRate"/> Desired bitrate of the recording in bps (default: 10M). Only supported on Android.
     /// </summary>
-    public async Task<CameraResult> StartRecordingAsync(string file, Size Resolution = default)
+    public async Task<CameraResult> StartRecordingAsync(string file, Size Resolution = default, int frameRate = 30, int bitRate = 10000000)
     {
         CameraResult result = CameraResult.AccessError;
         if (Camera != null)
@@ -479,7 +481,7 @@ public class CameraView : View, ICameraView
             }
             if (Handler != null && Handler is CameraViewHandler handler)
             {
-                result = await handler.StartRecordingAsync(file, Resolution);
+                result = await handler.StartRecordingAsync(file, Resolution, frameRate, bitRate);
                 if (result == CameraResult.Success)
                 {
                     BarCodeResults = null;

--- a/Camera.MAUI/CameraViewHandler.cs
+++ b/Camera.MAUI/CameraViewHandler.cs
@@ -75,16 +75,18 @@ internal partial class CameraViewHandler : ViewHandler<CameraView, PlatformView>
         }
         return Task.Run(() => { return CameraResult.AccessError; });
     }
-    public Task<CameraResult> StartRecordingAsync(string file, Size Resolution)
+
+    public Task<CameraResult> StartRecordingAsync(string file, Size Resolution, int frameRate, int bitRate)
     {
         if (PlatformView != null)
         {
-#if WINDOWS || ANDROID || IOS
-            return PlatformView.StartRecordingAsync(file, Resolution);
+#if WINDOWS || ANDROID || IOS || MACCATALYST
+            return PlatformView.StartRecordingAsync(file, Resolution, frameRate, bitRate);
 #endif
         }
         return Task.Run(() => { return CameraResult.AccessError; });
     }
+
     public Task<CameraResult> StopCameraAsync()
     {
         if (PlatformView != null)

--- a/Camera.MAUI/Platforms/Android/MauiCameraView.cs
+++ b/Camera.MAUI/Platforms/Android/MauiCameraView.cs
@@ -176,7 +176,27 @@ internal class MauiCameraView: GridLayout
                         audioManager.Mode = Mode.Normal;
                         mediaRecorder.SetAudioSource(AudioSource.Mic);
                         mediaRecorder.SetVideoSource(VideoSource.Surface);
-                        mediaRecorder.SetOutputFormat(OutputFormat.Mpeg4);
+                        var ext = System.IO.Path.GetExtension(file).ToLower();
+                        switch (ext)
+                        {
+                            case ".3gp":
+                                mediaRecorder.SetOutputFormat(OutputFormat.ThreeGpp);
+                                mediaRecorder.SetVideoEncoder(VideoEncoder.H264);
+                                mediaRecorder.SetAudioEncoder(AudioEncoder.Aac);
+                                break;
+                            case ".mp4":
+                                mediaRecorder.SetOutputFormat(OutputFormat.Mpeg4);
+                                mediaRecorder.SetVideoEncoder(VideoEncoder.H264);
+                                mediaRecorder.SetAudioEncoder(AudioEncoder.Aac);
+                                break;
+                            case ".webm":
+                                mediaRecorder.SetOutputFormat(OutputFormat.Webm);
+                                mediaRecorder.SetVideoEncoder(VideoEncoder.Vp8);
+                                mediaRecorder.SetAudioEncoder(AudioEncoder.Vorbis);
+                                break;
+                            default:
+                                throw new ArgumentException($"Invalid file extension '{ext}'! Please use '.3gp', '.mp4' or '.webm'!");
+                        }
                         mediaRecorder.SetOutputFile(file);
                         mediaRecorder.SetVideoEncodingBitRate(bitRate);
                         mediaRecorder.SetVideoFrameRate(frameRate);
@@ -186,8 +206,6 @@ internal class MauiCameraView: GridLayout
                             maxVideoSize = new((int)Resolution.Width, (int)Resolution.Height);
                         mediaRecorder.SetVideoSize(maxVideoSize.Width, maxVideoSize.Height);
 
-                        mediaRecorder.SetVideoEncoder(VideoEncoder.H264);
-                        mediaRecorder.SetAudioEncoder(AudioEncoder.Aac);
                         IWindowManager windowManager = context.GetSystemService(Context.WindowService).JavaCast<IWindowManager>();
 
                         int rotation = (int)windowManager.DefaultDisplay.Rotation;

--- a/Camera.MAUI/Platforms/Android/MauiCameraView.cs
+++ b/Camera.MAUI/Platforms/Android/MauiCameraView.cs
@@ -146,7 +146,7 @@ internal class MauiCameraView: GridLayout
         }
     }
 
-    internal async Task<CameraResult> StartRecordingAsync(string file, Microsoft.Maui.Graphics.Size Resolution)
+    internal async Task<CameraResult> StartRecordingAsync(string file, Microsoft.Maui.Graphics.Size Resolution, int frameRate, int bitRate)
     {
         var result = CameraResult.Success;
         if (initiated && !recording)
@@ -178,8 +178,8 @@ internal class MauiCameraView: GridLayout
                         mediaRecorder.SetVideoSource(VideoSource.Surface);
                         mediaRecorder.SetOutputFormat(OutputFormat.Mpeg4);
                         mediaRecorder.SetOutputFile(file);
-                        mediaRecorder.SetVideoEncodingBitRate(10000000);
-                        mediaRecorder.SetVideoFrameRate(30);
+                        mediaRecorder.SetVideoEncodingBitRate(bitRate);
+                        mediaRecorder.SetVideoFrameRate(frameRate);
 
                         var maxVideoSize = ChooseMaxVideoSize(map.GetOutputSizes(Class.FromType(typeof(ImageReader))));
                         if (Resolution.Width != 0 && Resolution.Height != 0)

--- a/Camera.MAUI/Platforms/Windows/MauiCameraView.cs
+++ b/Camera.MAUI/Platforms/Windows/MauiCameraView.cs
@@ -173,7 +173,7 @@ public sealed partial class MauiCameraView : UserControl, IDisposable
             }
         }
     }
-    internal async Task<CameraResult> StartRecordingAsync(string file, Size Resolution)
+    internal async Task<CameraResult> StartRecordingAsync(string file, Size Resolution, int frameRate, int bitRate)
     {
         CameraResult result = CameraResult.Success;
 


### PR DESCRIPTION
This PR addresses issues #8 and #9 by making `CameraView.StartRecordingAsync` more flexible on Android ...

1. It adds two optional parameters 'frameRate' and 'bitRate'. Both of them were previously hard-coded, and the hard-coded values are now used as default values for the parameters. Both parameters are only used on Android right now.

2. The extension of the provided file name is used to determine the output format (only on Android as well). The following options are supported (for other extensions, an `ArgumentException` is thrown):
    - .3gp (with H264 & AAC codecs)
    - .mp4 (with H264 & AAC codecs)
    - .webm (with VP8 & Vorbis codecs)

@mancda, @tpgalan Can you test this and tell me if it works well for you? Do you have any feedback?