### PR TITLE
Fix preview orientation on iOS

### DIFF
--- a/Camera.MAUI.Test/Platforms/iOS/Info.plist
+++ b/Camera.MAUI.Test/Platforms/iOS/Info.plist
@@ -18,6 +18,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -590,7 +590,9 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
         base.LayoutSubviews();
         CATransform3D transform = CATransform3D.MakeRotation(0, 0, 0, 1.0f);
         UIInterfaceOrientation orientation;
-        if (OperatingSystem.IsIOSVersionAtLeast(13))
+        if (OperatingSystem.IsIOSVersionAtLeast(15))
+            orientation = (UIApplication.SharedApplication.ConnectedScenes.ToArray().First(s => s is UIWindowScene) as UIWindowScene).InterfaceOrientation;
+        else if (OperatingSystem.IsIOSVersionAtLeast(13))
             orientation = UIApplication.SharedApplication.Windows.First().WindowScene.InterfaceOrientation;
         else
             orientation = UIApplication.SharedApplication.StatusBarOrientation;

--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -589,19 +589,24 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
     {
         base.LayoutSubviews();
         CATransform3D transform = CATransform3D.MakeRotation(0, 0, 0, 1.0f);
-        switch (UIDevice.CurrentDevice.Orientation)
+        UIInterfaceOrientation orientation;
+        if (OperatingSystem.IsIOSVersionAtLeast(13))
+            orientation = UIApplication.SharedApplication.Windows.First().WindowScene.InterfaceOrientation;
+        else
+            orientation = UIApplication.SharedApplication.StatusBarOrientation;
+        switch (orientation)
         {
-            case UIDeviceOrientation.Portrait:
+            case UIInterfaceOrientation.Portrait:
                 transform = CATransform3D.MakeRotation(0, 0, 0, 1.0f);
                 break;
-            case UIDeviceOrientation.PortraitUpsideDown:
+            case UIInterfaceOrientation.PortraitUpsideDown:
                 transform = CATransform3D.MakeRotation((nfloat)Math.PI, 0, 0, 1.0f);
                 break;
-            case UIDeviceOrientation.LandscapeLeft:
+            case UIInterfaceOrientation.LandscapeRight:
                 var rotation = cameraView.Camera?.Position == CameraPosition.Back ? -Math.PI / 2 : Math.PI / 2;
                 transform = CATransform3D.MakeRotation((nfloat)rotation, 0, 0, 1.0f);
                 break;
-            case UIDeviceOrientation.LandscapeRight:
+            case UIInterfaceOrientation.LandscapeLeft:
                 var rotation2 = cameraView.Camera?.Position == CameraPosition.Back ? Math.PI / 2 : -Math.PI /2;
                 transform = CATransform3D.MakeRotation((nfloat)rotation2, 0, 0, 1.0f);
                 break;


### PR DESCRIPTION
This fixes #19 by using `UIInterfaceOrientation` instead of `UIDeviceOrientation`. Tested on iOS 16.7.6 and 17.4 (with an iPhone and iPad).

It also extends the test app to allow all four interface orientations on iPhones (`PortraitUpsideDown` was missing).