### PR TITLE
Allow recording without audio

### DIFF
--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -113,7 +113,7 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
             }
         }
     }
-    public async Task<CameraResult> StartRecordingAsync(string file, Size Resolution, int frameRate, int bitRate)
+    public async Task<CameraResult> StartRecordingAsync(string file, Size Resolution, int frameRate, int bitRate, bool withAudio)
     {
         CameraResult result = CameraResult.Success;
         if (initiated)
@@ -121,7 +121,7 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
             if (started) StopCamera();
             if (await CameraView.RequestPermissions(true))
             {
-                if (cameraView.Camera != null && cameraView.Microphone != null && captureSession != null)
+                if (cameraView.Camera != null && captureSession != null)
                 {
                     try
                     {
@@ -138,9 +138,12 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
                         ForceAutoFocus();
                         captureInput = new AVCaptureDeviceInput(captureDevice, out var err);
                         captureSession.AddInput(captureInput);
-                        micDevice = micDevices.First(d => d.UniqueID == cameraView.Microphone.DeviceId);
-                        micInput = new AVCaptureDeviceInput(micDevice, out err);
-                        captureSession.AddInput(micInput);
+                        if (withAudio && cameraView.Microphone != null)
+                        {
+                            micDevice = micDevices.First(d => d.UniqueID == cameraView.Microphone.DeviceId);
+                            micInput = new AVCaptureDeviceInput(micDevice, out err);
+                            captureSession.AddInput(micInput);
+                        }
 
                         captureSession.AddOutput(videoDataOutput);
                         recordOutput = new AVCaptureMovieFileOutput();

--- a/Camera.MAUI/CameraView.cs
+++ b/Camera.MAUI/CameraView.cs
@@ -468,8 +468,9 @@ public class CameraView : View, ICameraView
     /// <paramref name="Resolution"/> Sets the Video Resolution. It must be in Camera.AvailableResolutions. If width or height is 0, max resolution will be taken.
     /// <paramref name="frameRate"/> Desired frame rate of the recording in Hz (default: 30). Only supported on Android.
     /// <paramref name="bitRate"/> Desired bitrate of the recording in bps (default: 10M). Only supported on Android.
+    /// <paramref name="withAudio"/> Record with audio (default: true).
     /// </summary>
-    public async Task<CameraResult> StartRecordingAsync(string file, Size Resolution = default, int frameRate = 30, int bitRate = 10000000)
+    public async Task<CameraResult> StartRecordingAsync(string file, Size Resolution = default, int frameRate = 30, int bitRate = 10000000, bool withAudio = true)
     {
         CameraResult result = CameraResult.AccessError;
         if (Camera != null)
@@ -481,7 +482,7 @@ public class CameraView : View, ICameraView
             }
             if (Handler != null && Handler is CameraViewHandler handler)
             {
-                result = await handler.StartRecordingAsync(file, Resolution, frameRate, bitRate);
+                result = await handler.StartRecordingAsync(file, Resolution, frameRate, bitRate, withAudio);
                 if (result == CameraResult.Success)
                 {
                     BarCodeResults = null;

--- a/Camera.MAUI/CameraViewHandler.cs
+++ b/Camera.MAUI/CameraViewHandler.cs
@@ -76,12 +76,12 @@ internal partial class CameraViewHandler : ViewHandler<CameraView, PlatformView>
         return Task.Run(() => { return CameraResult.AccessError; });
     }
 
-    public Task<CameraResult> StartRecordingAsync(string file, Size Resolution, int frameRate, int bitRate)
+    public Task<CameraResult> StartRecordingAsync(string file, Size Resolution, int frameRate, int bitRate, bool withAudio)
     {
         if (PlatformView != null)
         {
 #if WINDOWS || ANDROID || IOS || MACCATALYST
-            return PlatformView.StartRecordingAsync(file, Resolution, frameRate, bitRate);
+            return PlatformView.StartRecordingAsync(file, Resolution, frameRate, bitRate, withAudio);
 #endif
         }
         return Task.Run(() => { return CameraResult.AccessError; });

--- a/Camera.MAUI/Platforms/Android/MauiCameraView.cs
+++ b/Camera.MAUI/Platforms/Android/MauiCameraView.cs
@@ -146,7 +146,7 @@ internal class MauiCameraView: GridLayout
         }
     }
 
-    internal async Task<CameraResult> StartRecordingAsync(string file, Microsoft.Maui.Graphics.Size Resolution, int frameRate, int bitRate)
+    internal async Task<CameraResult> StartRecordingAsync(string file, Microsoft.Maui.Graphics.Size Resolution, int frameRate, int bitRate, bool withAudio)
     {
         var result = CameraResult.Success;
         if (initiated && !recording)
@@ -173,8 +173,11 @@ internal class MauiCameraView: GridLayout
                             mediaRecorder = new MediaRecorder(context);
                         else
                             mediaRecorder = new MediaRecorder();
-                        audioManager.Mode = Mode.Normal;
-                        mediaRecorder.SetAudioSource(AudioSource.Mic);
+                        if (withAudio)
+                        {
+                            audioManager.Mode = Mode.Normal;
+                            mediaRecorder.SetAudioSource(AudioSource.Mic);
+                        }
                         mediaRecorder.SetVideoSource(VideoSource.Surface);
                         var ext = System.IO.Path.GetExtension(file).ToLower();
                         switch (ext)
@@ -182,17 +185,20 @@ internal class MauiCameraView: GridLayout
                             case ".3gp":
                                 mediaRecorder.SetOutputFormat(OutputFormat.ThreeGpp);
                                 mediaRecorder.SetVideoEncoder(VideoEncoder.H264);
-                                mediaRecorder.SetAudioEncoder(AudioEncoder.Aac);
+                                if (withAudio)
+                                    mediaRecorder.SetAudioEncoder(AudioEncoder.Aac);
                                 break;
                             case ".mp4":
                                 mediaRecorder.SetOutputFormat(OutputFormat.Mpeg4);
                                 mediaRecorder.SetVideoEncoder(VideoEncoder.H264);
-                                mediaRecorder.SetAudioEncoder(AudioEncoder.Aac);
+                                if (withAudio)
+                                    mediaRecorder.SetAudioEncoder(AudioEncoder.Aac);
                                 break;
                             case ".webm":
                                 mediaRecorder.SetOutputFormat(OutputFormat.Webm);
                                 mediaRecorder.SetVideoEncoder(VideoEncoder.Vp8);
-                                mediaRecorder.SetAudioEncoder(AudioEncoder.Vorbis);
+                                if (withAudio)
+                                    mediaRecorder.SetAudioEncoder(AudioEncoder.Vorbis);
                                 break;
                             default:
                                 throw new ArgumentException($"Invalid file extension '{ext}'! Please use '.3gp', '.mp4' or '.webm'!");

--- a/Camera.MAUI/Platforms/Windows/MauiCameraView.cs
+++ b/Camera.MAUI/Platforms/Windows/MauiCameraView.cs
@@ -173,14 +173,14 @@ public sealed partial class MauiCameraView : UserControl, IDisposable
             }
         }
     }
-    internal async Task<CameraResult> StartRecordingAsync(string file, Size Resolution, int frameRate, int bitRate)
+    internal async Task<CameraResult> StartRecordingAsync(string file, Size Resolution, int frameRate, int bitRate, bool withAudio)
     {
         CameraResult result = CameraResult.Success;
 
         if (initiated)
         {
             if (started) await StopCameraAsync();
-            if (cameraView.Camera != null && cameraView.Microphone != null)
+            if (cameraView.Camera != null)
             {
                 while (!mediaLoaded) await Task.Delay(50);
                 started = true;
@@ -188,12 +188,14 @@ public sealed partial class MauiCameraView : UserControl, IDisposable
                 mediaCapture = new MediaCapture();
                 try
                 {
-                    await mediaCapture.InitializeAsync(new MediaCaptureInitializationSettings
+                    var mcis = new MediaCaptureInitializationSettings
                     {
                         VideoDeviceId = cameraView.Camera.DeviceId,
-                        MemoryPreference = MediaCaptureMemoryPreference.Cpu,
-                        AudioDeviceId = cameraView.Microphone.DeviceId
-                    });
+                        MemoryPreference = MediaCaptureMemoryPreference.Cpu
+                    };
+                    if (withAudio && cameraView.Microphone != null)
+                        mcis.AudioDeviceId = cameraView.Microphone.DeviceId;
+                    await mediaCapture.InitializeAsync(mcis);
 
                     MediaEncodingProfile profile = MediaEncodingProfile.CreateMp4(VideoEncodingQuality.Auto);
                     recordStream = new(file, FileMode.Create);

--- a/Camera.MAUI/Platforms/Windows/MauiCameraView.cs
+++ b/Camera.MAUI/Platforms/Windows/MauiCameraView.cs
@@ -194,7 +194,12 @@ public sealed partial class MauiCameraView : UserControl, IDisposable
                         MemoryPreference = MediaCaptureMemoryPreference.Cpu
                     };
                     if (withAudio && cameraView.Microphone != null)
+                    {
+                        mcis.StreamingCaptureMode = StreamingCaptureMode.AudioAndVideo;
                         mcis.AudioDeviceId = cameraView.Microphone.DeviceId;
+                    }
+                    else
+                        mcis.StreamingCaptureMode = StreamingCaptureMode.Video;
                     await mediaCapture.InitializeAsync(mcis);
 
                     MediaEncodingProfile profile = MediaEncodingProfile.CreateMp4(VideoEncodingQuality.Auto);


### PR DESCRIPTION
... by adding an  optional parameter `withAudio` in `CameraView.StartRecordingAsync`. Fixes #14.