### PR TITLE
fix test app build

### DIFF
--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -69,8 +69,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="11.2.0" />
-		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="5.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="9.1.1" />
+		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="4.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
 	</ItemGroup>
 


### PR DESCRIPTION
Reducing the minimum SDK required in global.json requires reducing some package versions also in test app.