### PR TITLE
Use absolute zoom factors on iOS

### DIFF
--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -97,19 +97,18 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
                         var virtualZoomFactors = new float[] { 1 }
                             .Concat(virtualDevice.VirtualDeviceSwitchOverVideoZoomFactors.Select(n => n.FloatValue))
                             .ToList();
-        
+
                         var constituentDevices = virtualDevice.ConstituentDevices.ToList();
                         var wideAngleIndex = constituentDevices.FindIndex(d => d.DeviceType == AVCaptureDeviceType.BuiltInWideAngleCamera);
-        
+
                         if (wideAngleIndex >= 0)
                         {
                             float wideAngleZoomFactor = virtualZoomFactors[wideAngleIndex];
-            
+
                             for (int i = 0; i < constituentDevices.Count && i < virtualZoomFactors.Count; i++)
                             {
                                 deviceTypeScales[constituentDevices[i].DeviceType] = virtualZoomFactors[i] / wideAngleZoomFactor;
                             }
-            
                             virtualDeviceScale = 1.0f / wideAngleZoomFactor;
                         }
                     }

--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -1,4 +1,4 @@
-﻿#if IOS || MACCATALYST
+#if IOS || MACCATALYST
 using System;
 using System.IO;
 using AVFoundation;
@@ -84,6 +84,10 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
                 var deviceDiscoverySession = AVCaptureDeviceDiscoverySession.Create(deviceTypes, AVMediaTypes.Video, AVCaptureDevicePosition.Unspecified);
                 camDevices = deviceDiscoverySession.Devices;
                 cameraView.Cameras.Clear();
+
+                float? wideAngleZoomFactor = (float?)camDevices.ToList()
+                    .Find(c => c.DeviceType == AVCaptureDeviceType.BuiltInWideAngleCamera)?.MinAvailableVideoZoomFactor;
+                
                 foreach (var device in camDevices)
                 {
                     CameraPosition position = device.Position switch
@@ -91,15 +95,34 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
                         AVCaptureDevicePosition.Back => CameraPosition.Back,
                         AVCaptureDevicePosition.Front => CameraPosition.Front,
                         _ => CameraPosition.Unknown
-                    };                    
+                    };
+
+                    float zoomFactorScale;
+                    
+                    if (OperatingSystem.IsIOSVersionAtLeast(18))
+                    {
+                        zoomFactorScale = (float)device.DisplayVideoZoomFactorMultiplier;
+                    }
+                    else if (position == CameraPosition.Back && wideAngleZoomFactor is float wideAngleFactor)
+                    {
+                        zoomFactorScale = 1 / wideAngleFactor;
+                    }
+                    else
+                    {
+                        zoomFactorScale = 1.0f;
+                    }
+
+                    float minZoomFactor = (float)device.MinAvailableVideoZoomFactor * zoomFactorScale;
+                    float maxZoomFactor = (float)device.MaxAvailableVideoZoomFactor * zoomFactorScale;
+                    
                     cameraView.Cameras.Add(new CameraInfo
                     {
                         Name = device.LocalizedName,
                         DeviceId = device.UniqueID,
                         Position = position,
                         HasFlashUnit = device.FlashAvailable,
-                        MinZoomFactor = (float)device.MinAvailableVideoZoomFactor,
-                        MaxZoomFactor = (float)device.MaxAvailableVideoZoomFactor,
+                        MinZoomFactor = minZoomFactor,
+                        MaxZoomFactor = maxZoomFactor,
                         HorizontalViewAngle = device.ActiveFormat.VideoFieldOfView * MathF.PI / 180,
                         AvailableResolutions = new() { new(1920, 1080), new(1280, 720), new(640, 480), new(352, 288) }
                     });
@@ -330,7 +353,8 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
             captureDevice.LockForConfiguration(out NSError error);
             if (error == null)
             {
-                captureDevice.VideoZoomFactor = Math.Clamp(zoom, cameraView.Camera.MinZoomFactor, cameraView.Camera.MaxZoomFactor);
+                float clampedZoom = Math.Clamp(zoom, cameraView.Camera.MinZoomFactor, cameraView.Camera.MaxZoomFactor) / cameraView.Camera.MinZoomFactor;
+                captureDevice.VideoZoomFactor = clampedZoom;
                 captureDevice.UnlockForConfiguration();
             }
         }


### PR DESCRIPTION
This PR changes the `MinAvailableVideoZoomFactor` and `MaxAvailableVideoZoomFactor` values from relative (minimum = 1.0 for all devices) to absolute (ex. minimum = 0.5 for ultrawide, minimum = 1.0 for default, minimum = 3.0 for telephoto).

We do this by multiplying min/max values by the `DisplayVideoZoomFactorMultiplier`, if available (iOS 18+). As a fallback, we determine the absolute zoom factor of the wide angle lens, and divide all `VirtualDeviceSwitchOverVideoZoomFactors` values by it. The result is the following:

```cs
// Before

// Back Ultra Wide Camera
{
    MaxZoomFactor = 123.75,
    MinZoomFactor = 1.0
}
```

```cs
// After

// Back Ultra Wide Camera
{
    MaxZoomFactor = 61.875,
    MinZoomFactor = 0.5
}
```

This PR also changes the exposed `ZoomFactor` value to be absolute on iOS, internally converting the value inside `SetZoomFactor` to be relative (as required by `AVCaptureDevice.VideoZoomFactor`).