### PR TITLE
Packages updates (ZXing, MAUI) etc

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,7 +41,7 @@ jobs:
         name: nupkg
         path: ./Camera.MAUI/bin/Release/*.nupkg
     - name: Build Test
-      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj -c Release -p:Version=$(git describe --tags)
+      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj -c Debug -p:Version=$(git describe --tags)
 
   macBuild:
     runs-on: macos-26
@@ -67,7 +67,7 @@ jobs:
     - name: Build Lib
       run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=$(git describe --tags)
     - name: Build Test
-      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release -p:Version=$(git describe --tags)
+      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Debug -p:Version=$(git describe --tags)
 
   linuxBuild:
     runs-on: ubuntu-latest
@@ -89,4 +89,4 @@ jobs:
     - name: Build Lib
       run: dotnet build Camera.MAUI/Camera.MAUI.csproj --no-restore -c Release -p:Version=$(git describe --tags)
     - name: Build Test
-      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Release -p:Version=$(git describe --tags)
+      run: dotnet build Camera.MAUI.Test/Camera.MAUI.Test.csproj --no-restore -c Debug -p:Version=$(git describe --tags)

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -70,8 +70,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="12.3.0" />
-		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="6.1.3" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
 	</ItemGroup>
 

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -72,7 +72,7 @@
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.0" />
 		<PackageReference Include="CommunityToolkit.Maui.MediaElement" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Camera.MAUI.Test/Camera.MAUI.Test.csproj
+++ b/Camera.MAUI.Test/Camera.MAUI.Test.csproj
@@ -9,7 +9,7 @@
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Camera.MAUI.Test</RootNamespace>
 		<UseMaui>true</UseMaui>
-		<MauiVersion>10.0.20</MauiVersion>
+		<MauiVersion>10.0.31</MauiVersion>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 

--- a/Camera.MAUI.Test/MauiProgram.cs
+++ b/Camera.MAUI.Test/MauiProgram.cs
@@ -13,7 +13,7 @@ namespace Camera.MAUI.Test
             builder
                 .UseMauiApp<App>()
                 .UseMauiCommunityToolkit()
-                .UseMauiCommunityToolkitMediaElement()
+                .UseMauiCommunityToolkitMediaElement(isAndroidForegroundServiceEnabled: true)
                 .UseMauiCameraView()
                 .ConfigureFonts(fonts =>
                 {

--- a/Camera.MAUI/Apple/MauiCameraView.cs
+++ b/Camera.MAUI/Apple/MauiCameraView.cs
@@ -1,4 +1,4 @@
-#if IOS || MACCATALYST
+﻿#if IOS || MACCATALYST
 using System;
 using System.IO;
 using AVFoundation;
@@ -78,14 +78,14 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
             {
                 AVCaptureDeviceType[] deviceTypes = null;
                 if (OperatingSystem.IsIOSVersionAtLeast(13))
-                    deviceTypes = new AVCaptureDeviceType[] { AVCaptureDeviceType.BuiltInWideAngleCamera, AVCaptureDeviceType.BuiltInUltraWideCamera, AVCaptureDeviceType.BuiltInDualWideCamera, AVCaptureDeviceType.BuiltInTripleCamera, AVCaptureDeviceType.BuiltInTelephotoCamera };
+                    deviceTypes = [AVCaptureDeviceType.BuiltInWideAngleCamera, AVCaptureDeviceType.BuiltInUltraWideCamera, AVCaptureDeviceType.BuiltInDualWideCamera, AVCaptureDeviceType.BuiltInTripleCamera, AVCaptureDeviceType.BuiltInTelephotoCamera];
                 else
-                    deviceTypes = new AVCaptureDeviceType[] { AVCaptureDeviceType.BuiltInWideAngleCamera, AVCaptureDeviceType.BuiltInTelephotoCamera };
+                    deviceTypes = [AVCaptureDeviceType.BuiltInWideAngleCamera, AVCaptureDeviceType.BuiltInTelephotoCamera];
                 var deviceDiscoverySession = AVCaptureDeviceDiscoverySession.Create(deviceTypes, AVMediaTypes.Video, AVCaptureDevicePosition.Unspecified);
                 camDevices = deviceDiscoverySession.Devices;
                 cameraView.Cameras.Clear();
 
-                Dictionary<AVCaptureDeviceType, float> deviceTypeScales = new();
+                Dictionary<AVCaptureDeviceType, float> deviceTypeScales = [];
                 float virtualDeviceScale = 1.0f;
 
                 if (OperatingSystem.IsIOSVersionAtLeast(13))
@@ -161,11 +161,11 @@ internal class MauiCameraView : UIView, IAVCaptureVideoDataOutputSampleBufferDel
                         MinZoomFactor = minZoomFactor,
                         MaxZoomFactor = maxZoomFactor,
                         HorizontalViewAngle = device.ActiveFormat.VideoFieldOfView * MathF.PI / 180,
-                        AvailableResolutions = new() { new(1920, 1080), new(1280, 720), new(640, 480), new(352, 288) }
+                        AvailableResolutions = [new(1920, 1080), new(1280, 720), new(640, 480), new(352, 288)]
                     });
                 }
                 deviceDiscoverySession.Dispose();
-                var aSession = AVCaptureDeviceDiscoverySession.Create(new AVCaptureDeviceType[] { AVCaptureDeviceType.BuiltInMicrophone }, AVMediaTypes.Audio, AVCaptureDevicePosition.Unspecified);
+                var aSession = AVCaptureDeviceDiscoverySession.Create([AVCaptureDeviceType.BuiltInMicrophone], AVMediaTypes.Audio, AVCaptureDevicePosition.Unspecified);
                 micDevices = aSession.Devices;
                 cameraView.Microphones.Clear();
                 foreach (var device in micDevices)

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -39,7 +39,7 @@
 		<MauiVersion>9.0.51</MauiVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition="$(TargetFramework.Contains('net10'))">
-		<MauiVersion>10.0.20</MauiVersion>
+		<MauiVersion>10.0.31</MauiVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Camera.MAUI/Camera.MAUI.csproj
+++ b/Camera.MAUI/Camera.MAUI.csproj
@@ -63,7 +63,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="ZXing.Net" Version="0.16.10" />
+		<PackageReference Include="ZXing.Net" Version="0.16.11" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This PR updates some packages to the latest version, most notably:
* ZXing.Net to 0.16.11
* MAUI to 10.0.31

Moreover it updates some packages in the test app (e.g. CommunityToolkit.Maui), simplifies a few expressions in the code and speeds up the CI builds a bit.